### PR TITLE
This pull request resolves a build failure caused by an invalid-constexpr error on modern compilers (like AppleClang).

### DIFF
--- a/include/event_camera_renderer/check_endian.h
+++ b/include/event_camera_renderer/check_endian.h
@@ -23,7 +23,7 @@ namespace event_camera_renderer
 namespace check_endian
 {
 // check endianness
-inline constexpr bool isBigEndian()
+inline bool isBigEndian()
 {
   const union {
     uint32_t i;


### PR DESCRIPTION
This pull request resolves a build failure caused by an `invalid-constexpr` error on modern compilers (like `AppleClang).`

The `isBigEndian()` function was incorrectly marked as constexpr because its logic, which relies on a union to check memory layout, is not permitted in a constant expression context according to the C++ standard. This change removes the `constexpr` keyword, allowing the function to be evaluated at runtime, which is its intended purpose.

The functionality of the endianness check remains unchanged.