### PR TITLE
Add max_frame_queue param to bound the pending-frame backlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Parameters:
   ``time_slice``. This image shows the difference (left is sharp,
   right is time_slice): 
   <img src="images/time_slice_vs_sharp.png" width="800"/>
+- ``max_frame_queue`` Maximum number of pending frame slots. When events
+  stop (or the decoder runs slower than real time) frame slots accumulate;
+  once this many are queued, new slots are dropped (the oldest are kept so a
+  slow decoder can still catch up). A high value replays a long backlog when
+  motion resumes (seconds of latency after a quiet period); a low value (e.g.
+  ``3``) keeps latency bounded. Default: 1000 (preserves prior behavior).
 
 ## License
 

--- a/include/event_camera_renderer/renderer.h
+++ b/include/event_camera_renderer/renderer.h
@@ -80,6 +80,7 @@ private:
   PeriodEstimator framePeriod_;
   int eventQueueMemoryLimit_{0};
   size_t eventQueueMemory_{0};
+  int maxFrameQueue_{1000};  // cap on pending frame slots (bounds post-quiet latency)
 };
 std::ostream & operator<<(std::ostream & os, const Renderer::FrameTime & ft);
 }  // namespace event_camera_renderer

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -55,6 +55,7 @@ Renderer::Renderer(const rclcpp::NodeOptions & options)
     throw std::runtime_error("invalid display type!");
   }
   this->get_parameter_or("event_queue_memory_limit", eventQueueMemoryLimit_, 10 * 1024 * 1024);
+  this->get_parameter_or("max_frame_queue", maxFrameQueue_, 1000);
 
   double fps;
   this->get_parameter_or("fps", fps, 25.0);
@@ -133,9 +134,8 @@ void Renderer::subscriptionCheckTimerExpired()
 
 void Renderer::addNewFrame(const FrameTime & ft)
 {
-  if (frames_.size() >= 1000) {
-    RCLCPP_WARN_THROTTLE(
-      get_logger(), *get_clock(), 5000, "frames dropped because no events are received!");
+  if (frames_.size() >= static_cast<size_t>(maxFrameQueue_)) {
+    RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 5000, "frame queue full; dropping new frames");
   } else {
     frames_.push_back(ft);
   }


### PR DESCRIPTION
## Problem
addNewFrame queues a frame slot per target frame time, capped at a hardcoded 1000. During a quiet period (no events, or a decoder slower than real time) the queue fills with stale slots, and when motion resumes the renderer replays the entire backlog before live frames — up to ~1000 frames / seconds of latency after any pause.

## Change
Make the cap a ROS parameter `max_frame_queue` (default 1000, so existing behavior is unchanged). A low value such as 3 bounds the post-quiet latency, while the oldest slots are kept (drop-newest) so a slower-than-real-time decoder can still reach its oldest target and keep emitting. The warning message is updated since it is no longer specific to the no-events case; the param is documented in the README.